### PR TITLE
Make home layout responsive

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,25 +3,31 @@ layout: default
 ---
 
 {% for post in paginator.posts %}
-  <div class="posts-container">
-    <h1>
-      <a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a>
-    </h1>
-    {% if post.image %}
-      <div class="thumbnail-container">
-        <a href="{{ site.github.url }}{{ post.url }}"><img src="{{ site.github.url }}/assets/img/{{ post.image }}"></a>
+  <article class="post-card">
+    <div class="post-card__body">
+      <div class="post-card__content">
+        <h1>
+          <a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a>
+        </h1>
+        <p>
+          {% if post.preview %}
+            {{post.preview}}
+          {% else %}
+            {{ post.content | strip_html | truncate: 350 }}
+          {% endif %}
+          <a href="{{ site.github.url }}{{ post.url }}">Read more</a>
+          <span class="post-date"><i class="fa fa-calendar" aria-hidden="true"></i> {{ post.date | date_to_string }} - <i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</span>
+        </p>
       </div>
-    {% endif %}
-    <p>
-      {% if post.preview %}
-        {{post.preview}}
-      {% else %}
-        {{ post.content | strip_html | truncate: 350 }} 
+      {% if post.image %}
+        <div class="post-card__media">
+          <div class="thumbnail-container">
+            <a href="{{ site.github.url }}{{ post.url }}"><img src="{{ site.github.url }}/assets/img/{{ post.image }}"></a>
+          </div>
+        </div>
       {% endif %}
-      <a href="{{ site.github.url }}{{ post.url }}">Read more</a>
-      <span class="post-date"><i class="fa fa-calendar" aria-hidden="true"></i> {{ post.date | date_to_string }} - <i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</span>
-    </p>
-  </div>
+    </div>
+  </article>
 {% endfor %}
 <!-- Pagination links -->
 <div class="pagination">

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -2,7 +2,12 @@
   Posts
 */
 
-.posts-container {
+.post-card {
+  margin-bottom: 5rem;
+}
+
+.posts-container,
+.posts-container2 {
   margin-bottom: 5rem;
   padding: 0px;
   list-style: none;
@@ -10,8 +15,21 @@
 
 .posts-container2 {
   margin-bottom: 0rem;
-  padding: 0px;
+}
+
+.post-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.post-card__content {
   list-style: none;
+}
+
+.post-card__media {
+  display: flex;
+  justify-content: center;
 }
 
 /*
@@ -28,6 +46,28 @@
 .thumbnail-container img{
   margin-top: 0%; /* -11.5%; */
   margin-bottom: 0%; /* -11.5%; */
+}
+
+.post-card__body {
+  @media (max-width: 900px) {
+    align-items: flex-start;
+    flex-direction: row;
+    gap: 1.5rem;
+
+    .post-card__media {
+      order: 0;
+      flex: 0 0 260px;
+      justify-content: flex-start;
+
+      .thumbnail-container {
+        margin-bottom: 0;
+      }
+    }
+
+    .post-card__content {
+      order: 1;
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
## Summary
- refactor the home layout to reuse a single post card structure
- add responsive styling so the layout matches the desktop home view and switches to the compact home2 presentation on small screens
- keep existing pagination and legacy classes while centering the image block and text consistently

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available before bundle install)*
- bundle install *(fails: unable to download gems due to 403 from rubygems.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ab35874c8327a77aa0ea5c5efa7b)